### PR TITLE
Fix non-self-contained output handling

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,7 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.AspNetCore.StaticFiles" Version="2.3.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
+    <PackageVersion Include="Polly" Version="8.2.0" />
   </ItemGroup>
   <!--Test-->
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@ The compiler is developed in C# using .NET 9's IL assembly writing capabilities.
 2. **Move to the Output Directory**  
    After building, switch to the folder containing the compiled artifacts.
 
-3. **Compile Your AtLang Program**  
+3. **Compile Your AtLang Program**
    ```bash
-   dotnet AtLangCompiler.dll your_program.at
+   dotnet AtLangCompiler.dll your_program.at [targetOS] [--no-self-contained]
    ```
-4. **Run the Generated Program**  
+   - `targetOS` defaults to `Windows` if omitted. Use values like `Linux` or `OSX` to target other platforms.
+   - Use `--no-self-contained` to produce a framework-dependent executable.
+4. **Run the Generated Program**
    ```bash
-   dotnet your_program.exe
+   ./your_program.exe
    ```
 
 ---

--- a/compiler/AtLangCompiler.csproj
+++ b/compiler/AtLangCompiler.csproj
@@ -8,6 +8,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.StaticFiles" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Polly" />
         <Reference Include="Microsoft.NET.HostModel">
             <HintPath>$(MSBuildSDKsPath)/../Microsoft.NET.HostModel.dll</HintPath>
         </Reference>

--- a/compiler/Program.cs
+++ b/compiler/Program.cs
@@ -6,17 +6,26 @@ public class Program
 {
     public static void Main(string[] args)
     {
-        if (args.Length < 1 || args.Length > 2 || string.IsNullOrWhiteSpace(args[0]))
+        if (args.Length < 1 || args.Length > 3 || string.IsNullOrWhiteSpace(args[0]))
         {
             Console.WriteLine("Incorrect arguments!");
-            Console.WriteLine("Usage: AtLangCompiler.dll <source file path> [targetOS]");
+            Console.WriteLine("Usage: AtLangCompiler.dll <source file path> [targetOS] [--no-self-contained]");
             return;
         }
 
-        OSPlatform targetOS = OSPlatform.Linux;
-        if (args.Length == 2)
+        OSPlatform targetOS = OSPlatform.Windows;
+        bool selfContained = true;
+
+        for (int i = 1; i < args.Length; i++)
         {
-            targetOS = OSPlatform.Create(args[1]);
+            if (string.Equals(args[i], "--no-self-contained", StringComparison.OrdinalIgnoreCase))
+            {
+                selfContained = false;
+            }
+            else
+            {
+                targetOS = OSPlatform.Create(args[i]);
+            }
         }
 
         string atPath = Path.GetFullPath(args[0]);
@@ -36,7 +45,7 @@ public class Program
 
         try
         {
-            Compiler.CompileToIL(code, outputPath, targetOS);
+            Compiler.CompileToIL(code, outputPath, targetOS, selfContained);
             sw.Stop();
         }
         catch (Exception ex)

--- a/compiler/Utils/FileUtil.cs
+++ b/compiler/Utils/FileUtil.cs
@@ -1,0 +1,37 @@
+using System;
+using System.IO;
+using Polly;
+using Polly.Retry;
+
+namespace AtLangCompiler;
+
+public static class FileUtil
+{
+    public static void CopyWithRetries(string source, string destination)
+    {
+        var options = new RetryStrategyOptions
+        {
+            ShouldHandle = new PredicateBuilder().Handle<Exception>(),
+            BackoffType = DelayBackoffType.Exponential,
+            UseJitter = true,
+            MaxRetryAttempts = 10,
+            Delay = TimeSpan.FromMilliseconds(100),
+            OnRetry = args =>
+            {
+                Console.WriteLine($"Retrying copy '{source}' -> '{destination}' in {args.RetryDelay.TotalMilliseconds}ms...");
+                return default;
+            }
+        };
+
+        var pipeline = new ResiliencePipelineBuilder().AddRetry(options).Build();
+        try
+        {
+            pipeline.Execute(() => File.Copy(source, destination, true));
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Failed to copy '{source}' to '{destination}': {ex.Message}");
+            throw;
+        }
+    }
+}

--- a/test/SnapshotTests.cs
+++ b/test/SnapshotTests.cs
@@ -17,14 +17,14 @@ namespace AtLangCompiler.Tests
 
             string assemblyName = Path.GetFileNameWithoutExtension(atFilePath);
             string tempFolder = Path.Combine(Path.GetTempPath(), nameof(SnapshotTests), Guid.NewGuid().ToString());
-            string tempAssembly = Path.Combine(tempFolder, assemblyName + ".dll");
+            string tempAssembly = Path.Combine(tempFolder, assemblyName + ".exe");
             Directory.CreateDirectory(tempFolder);
 
             try
             {
                 // Compile the .at file to IL
                 string atFileContents = File.ReadAllText(atFilePath);
-                Compiler.CompileToIL(atFileContents, tempAssembly, OSPlatform.Linux);
+                Compiler.CompileToIL(atFileContents, tempAssembly, OSPlatform.Linux, selfContained: false);
 
                 Assert.IsTrue(File.Exists(tempAssembly), $"Compilation failed: {tempAssembly} was not generated.");
 


### PR DESCRIPTION
## Summary
- add Polly package for file copy retries
- copy generated artifacts when not bundling
- run bundler into a temp folder and copy final binary with retry logic

## Testing
- `dotnet build atlang.sln --configuration Release`
- `dotnet test atlang.sln --no-build --configuration Release --verbosity normal -p:TestingPlatformCommandLineArguments="--report-trx --results-directory TestResults/ --coverage"`


------
https://chatgpt.com/codex/tasks/task_e_6885eec3922083328780cc65d2fc169d