### PR TITLE
Update build workflow for full RID coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,119 @@ jobs:
         echo "Tests failed. Failing pipeline."
         exit 1
 
-    - name: Upload compiler artifact
+    - name: Publish self-contained compiler for all RIDs
+      run: bash build/publish.sh
+
+    - name: Upload compiler artifact (win-x64)
       uses: actions/upload-artifact@v4
       with:
-        name: compiler-artifact
-        path: compiler/bin/Release/net9.0/
+        name: compiler-win-x64
+        path: published/win-x64
+
+    - name: Upload compiler artifact (win-x86)
+      uses: actions/upload-artifact@v4
+      with:
+        name: compiler-win-x86
+        path: published/win-x86
+
+    - name: Upload compiler artifact (win-arm64)
+      uses: actions/upload-artifact@v4
+      with:
+        name: compiler-win-arm64
+        path: published/win-arm64
+
+    - name: Upload compiler artifact (linux-x64)
+      uses: actions/upload-artifact@v4
+      with:
+        name: compiler-linux-x64
+        path: published/linux-x64
+
+    - name: Upload compiler artifact (linux-musl-x64)
+      uses: actions/upload-artifact@v4
+      with:
+        name: compiler-linux-musl-x64
+        path: published/linux-musl-x64
+
+    - name: Upload compiler artifact (linux-musl-arm64)
+      uses: actions/upload-artifact@v4
+      with:
+        name: compiler-linux-musl-arm64
+        path: published/linux-musl-arm64
+
+    - name: Upload compiler artifact (linux-arm)
+      uses: actions/upload-artifact@v4
+      with:
+        name: compiler-linux-arm
+        path: published/linux-arm
+
+    - name: Upload compiler artifact (linux-arm64)
+      uses: actions/upload-artifact@v4
+      with:
+        name: compiler-linux-arm64
+        path: published/linux-arm64
+
+    - name: Upload compiler artifact (linux-bionic-arm64)
+      uses: actions/upload-artifact@v4
+      with:
+        name: compiler-linux-bionic-arm64
+        path: published/linux-bionic-arm64
+
+    - name: Upload compiler artifact (linux-loongarch64)
+      uses: actions/upload-artifact@v4
+      with:
+        name: compiler-linux-loongarch64
+        path: published/linux-loongarch64
+
+    - name: Upload compiler artifact (osx-x64)
+      uses: actions/upload-artifact@v4
+      with:
+        name: compiler-osx-x64
+        path: published/osx-x64
+
+    - name: Upload compiler artifact (osx-arm64)
+      uses: actions/upload-artifact@v4
+      with:
+        name: compiler-osx-arm64
+        path: published/osx-arm64
+
+    - name: Upload compiler artifact (ios-arm64)
+      uses: actions/upload-artifact@v4
+      with:
+        name: compiler-ios-arm64
+        path: published/ios-arm64
+
+    - name: Upload compiler artifact (iossimulator-arm64)
+      uses: actions/upload-artifact@v4
+      with:
+        name: compiler-iossimulator-arm64
+        path: published/iossimulator-arm64
+
+    - name: Upload compiler artifact (iossimulator-x64)
+      uses: actions/upload-artifact@v4
+      with:
+        name: compiler-iossimulator-x64
+        path: published/iossimulator-x64
+
+    - name: Upload compiler artifact (android-arm64)
+      uses: actions/upload-artifact@v4
+      with:
+        name: compiler-android-arm64
+        path: published/android-arm64
+
+    - name: Upload compiler artifact (android-arm)
+      uses: actions/upload-artifact@v4
+      with:
+        name: compiler-android-arm
+        path: published/android-arm
+
+    - name: Upload compiler artifact (android-x64)
+      uses: actions/upload-artifact@v4
+      with:
+        name: compiler-android-x64
+        path: published/android-x64
+
+    - name: Upload compiler artifact (android-x86)
+      uses: actions/upload-artifact@v4
+      with:
+        name: compiler-android-x86
+        path: published/android-x86

--- a/build/publish.sh
+++ b/build/publish.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+
+rids=(
+  win-x64
+  win-x86
+  win-arm64
+  linux-x64
+  linux-musl-x64
+  linux-musl-arm64
+  linux-arm
+  linux-arm64
+  linux-bionic-arm64
+  linux-loongarch64
+  osx-x64
+  osx-arm64
+  ios-arm64
+  iossimulator-arm64
+  iossimulator-x64
+  android-arm64
+  android-arm
+  android-x64
+  android-x86
+)
+
+output_dir="${repo_root}/published"
+rm -rf "$output_dir"
+mkdir -p "$output_dir"
+
+for rid in "${rids[@]}"; do
+  dest="$output_dir/$rid"
+  echo "Publishing for $rid..."
+  dotnet publish "${repo_root}/compiler/AtLangCompiler.csproj" -c Release -r "$rid" --self-contained -o "$dest"
+done


### PR DESCRIPTION
## Summary
- build/publish.sh publishes the compiler for many platforms
- workflow calls the publish script and uploads an artifact for each RID

## Testing
- `dotnet restore atlang.sln`
- `dotnet build atlang.sln --configuration Release --no-restore`
- `dotnet test atlang.sln --no-build --configuration Release --verbosity normal -p:TestingPlatformCommandLineArguments="--report-trx --results-directory TestResults/ --coverage"`


------
https://chatgpt.com/codex/tasks/task_e_688641071c6883328f6edba312333457