### PR TITLE
Fix HostModel issue

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.StaticFiles" Version="2.3.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
     <PackageVersion Include="Polly" Version="8.2.0" />
+    <PackageVersion Include="Microsoft.NET.HostModel" Version="9.0.7" />
   </ItemGroup>
   <!--Test-->
   <ItemGroup>

--- a/compiler/AtLangCompiler.csproj
+++ b/compiler/AtLangCompiler.csproj
@@ -9,9 +9,7 @@
         <PackageReference Include="Microsoft.AspNetCore.StaticFiles" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Polly" />
-        <Reference Include="Microsoft.NET.HostModel">
-            <HintPath>$(MSBuildSDKsPath)/../Microsoft.NET.HostModel.dll</HintPath>
-        </Reference>
+        <PackageReference Include="Microsoft.NET.HostModel" />
     </ItemGroup>
 
 </Project>

--- a/test/Tests.csproj
+++ b/test/Tests.csproj
@@ -22,9 +22,7 @@
         <PackageReference Include="runtime.win-x64.Microsoft.NETCore.ILDAsm" GeneratePathProperty="true" />
         <PackageReference Include="runtime.linux-x64.Microsoft.NETCore.ILDAsm" GeneratePathProperty="true" />
         <PackageReference Include="runtime.osx-x64.Microsoft.NETCore.ILDAsm" GeneratePathProperty="true" />
-        <Reference Include="Microsoft.NET.HostModel">
-            <HintPath>$(MSBuildSDKsPath)/../Microsoft.NET.HostModel.dll</HintPath>
-        </Reference>
+        <PackageReference Include="Microsoft.NET.HostModel" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- restore cross-platform publish workflow
- reference Microsoft.NET.HostModel from NuGet
- revert publish script to build for every RID

## Testing
- `dotnet test atlang.sln --no-build --configuration Release --verbosity normal -p:TestingPlatformCommandLineArguments="--report-trx --results-directory TestResults/ --coverage"` *(fails: compatible .NET SDK not found)*
- `bash build/publish.sh` *(fails: compatible .NET SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886701772348332860312d86c81eba5