### PR TITLE
Use typed locals for variables

### DIFF
--- a/compiler/Compiler/Compiler.cs
+++ b/compiler/Compiler/Compiler.cs
@@ -44,12 +44,7 @@ public static class Compiler
         );
 
         ILGenerator il = entryPoint.GetILGenerator();
-        LocalBuilder dictLocal = il.DeclareLocal(typeof(Dictionary<string, object>));
-        ILMethodEmitterManager ilEmitter = new ILMethodEmitterManager(il, dictLocal);
-
-        // We'll store variables in a Dictionary<string,object>
-        il.Emit(OpCodes.Newobj, typeof(Dictionary<string, object>).GetConstructor(Type.EmptyTypes)!);
-        il.Emit(OpCodes.Stloc, dictLocal);
+        ILMethodEmitterManager ilEmitter = new ILMethodEmitterManager(il);
 
         // Emit IL for each statement
         foreach (ASTNode node in ast)

--- a/compiler/ILEmitter/DIConfiguration.cs
+++ b/compiler/ILEmitter/DIConfiguration.cs
@@ -6,13 +6,12 @@ namespace AtLangCompiler.ILEmitter;
 
 internal static class DIConfiguration
 {
-    public static IServiceProvider ConfigureServices(ILGenerator il, LocalBuilder dictLocal, ILMethodEmitterManager emitter)
+    public static IServiceProvider ConfigureServices(ILGenerator il, ILMethodEmitterManager emitter)
     {
         ServiceCollection serviceCollection = new ServiceCollection();
 
         // Register shared dependencies
         serviceCollection.AddSingleton(il);
-        serviceCollection.AddSingleton(dictLocal);
         serviceCollection.AddSingleton(emitter);
 
         // Register all emitters dynamically

--- a/compiler/Methods/Exit.cs
+++ b/compiler/Methods/Exit.cs
@@ -1,6 +1,5 @@
 using AtLangCompiler.ILEmitter;
 using System;
-using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
 
@@ -65,19 +64,16 @@ internal class ExitCodeStatementParser : IStatementParser
 internal class Exit : IMethodEmitter<ExitCodeStatement>
 {
     private readonly ILGenerator il;
-    private readonly LocalBuilder dictLocal;
     private readonly ILMethodEmitterManager emitter;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Exit"/> class.
     /// </summary>
     /// <param name="il">The <see cref="ILGenerator"/> instance used for emitting IL code.</param>
-    /// <param name="dictLocal">The local variable holding the runtime dictionary.</param>
     /// <param name="emitter">The <see cref="ILMethodEmitterManager"/> used to emit sub-expressions.</param>
-    public Exit(ILGenerator il, LocalBuilder dictLocal, ILMethodEmitterManager emitter)
+    public Exit(ILGenerator il, ILMethodEmitterManager emitter)
     {
         this.il = il ?? throw new ArgumentNullException(nameof(il));
-        this.dictLocal = dictLocal ?? throw new ArgumentNullException(nameof(dictLocal));
         this.emitter = emitter ?? throw new ArgumentNullException(nameof(emitter));
     }
 

--- a/compiler/Methods/Print.cs
+++ b/compiler/Methods/Print.cs
@@ -34,13 +34,11 @@ internal class PrintStatementParser : IStatementParser
 internal class Print : IMethodEmitter<PrintStatement>
 {
     private readonly ILGenerator il;
-    private readonly LocalBuilder dictLocal;
     private readonly ILMethodEmitterManager emitter;
 
-    public Print(ILGenerator il, LocalBuilder dictLocal, ILMethodEmitterManager emitter)
+    public Print(ILGenerator il, ILMethodEmitterManager emitter)
     {
         this.il = il ?? throw new ArgumentNullException(nameof(il));
-        this.dictLocal = dictLocal ?? throw new ArgumentNullException(nameof(dictLocal));
         this.emitter = emitter ?? throw new ArgumentNullException(nameof(emitter));
     }
 


### PR DESCRIPTION
## Summary
- remove runtime dictionary and store variables in typed locals
- add utility methods to `ILMethodEmitterManager`
- update emitters to use typed variables
- update DI configuration and compiler to match

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886080f973083329d7abd8c74c88e12