### PR TITLE
Enable central package transitive pinning

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,4 +1,8 @@
 <Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
   <!--Runtime-->
   <ItemGroup>
     <PackageVersion Include="Microsoft.AspNetCore.StaticFiles" Version="2.3.0" />


### PR DESCRIPTION
## Summary
- enable central package management via Directory.Packages.props
- explicitly enable transitive package version pinning

## Testing
- `/tmp/dotnet/dotnet restore`
- `/tmp/dotnet/dotnet test` *(fails: MSB4017 unexpected logger failure)*

------
https://chatgpt.com/codex/tasks/task_e_68aa84b4ee0c83328a8d15dc95503d92